### PR TITLE
[Fix] Movable racks in same time

### DIFF
--- a/gameboardwidget.cpp
+++ b/gameboardwidget.cpp
@@ -10,53 +10,40 @@ GameBoardWidget::~GameBoardWidget()
 
 void GameBoardWidget::updateGameBoard()
 {
+    if(mLMovingUp)
+    {
+        mLeftRack.mY1 -= mRackSpeed;
+        mLeftRack.mY2 = mLeftRack.mY1 + mRackLength;
+    }
+    if(mLMovingDo)
+    {
+        mLeftRack.mY1 += mRackSpeed;
+        mLeftRack.mY2 = mLeftRack.mY1 + mRackLength;
+    }
+    if(mRMovingUp)
+    {
+        mRightRack.mY1 -= mRackSpeed;
+        mRightRack.mY2 = mRightRack.mY1 + mRackLength;
+    }
+    if(mRMovingDo)
+    {
+        mRightRack.mY1 += mRackSpeed;
+        mRightRack.mY2 = mRightRack.mY1 + mRackLength;
+    }
+
+    //TODO: update ball position here
+
     update();
-}
-
-void GameBoardWidget::leftRackMove(int iDirection)
-{
-    while(mLMoving)
-    {
-        if ((mLeftRack.mY1 + iDirection) >= 0 && (mLeftRack.mY1 + iDirection + mRackLength) <= (mSize.height() - 60))
-        {
-            mLeftRack.mY1 += iDirection;
-            mLeftRack.mY2 = mLeftRack.mY1 + mRackLength;
-        }
-
-        sleep(1);
-        std::cout << "mLeftRack.mY1: " << mLeftRack.mY1 << std::endl;
-
-        update();
-    }
 
 }
 
-void GameBoardWidget::rightRackMove(int iDirection)
-{
-    while(mRMoving)
-    {
-        if ((mRightRack.mY1 + iDirection) >= 0 && (mRightRack.mY1 + iDirection + mRackLength) <= (mSize.height() - 60))
-        {
-            mRightRack.mY1 += iDirection;
-            mRightRack.mY2 = mRightRack.mY1 + mRackLength;
-        }
-
-        std::cout << "mRightRack.mY1: " << mRightRack.mY1 << std::endl;
-
-        update();
-
-        sleep(1);
-
-
-    }
-
-}
 
 void GameBoardWidget::init(QSize iSize)
 {
     mSize = iSize;
     mRackPenSize = 20;
     mRackLength = 90;
+    mRackSpeed = 4;
 
     mRightRack.mX1 = mSize.width() - (mRackPenSize * 2) + 5;
     mRightRack.mY1 = 1;
@@ -78,7 +65,7 @@ void GameBoardWidget::checkPositions()
     }
     if(mLeftRack.mY1 + mRackLength > (mSize.height() - 60))
     {
-        mLeftRack.mY1 -= 1;
+        mLeftRack.mY1 -= mRackSpeed;
     }
     mLeftRack.mY2 = mLeftRack.mY1 + mRackLength;
 
@@ -88,7 +75,7 @@ void GameBoardWidget::checkPositions()
     }
     if(mRightRack.mY1 + mRackLength > (mSize.height() - 60))
     {
-        mRightRack.mY1 -= 1;
+        mRightRack.mY1 -= mRackSpeed;
     }
     mRightRack.mY2 = mRightRack.mY1 + mRackLength;
 }

--- a/gameboardwidget.cpp
+++ b/gameboardwidget.cpp
@@ -52,11 +52,36 @@ void GameBoardWidget::init(QSize iSize)
 
 }
 
+void GameBoardWidget::checkPositions()
+{
+    if (mLeftRack.mY1 <= 0)
+    {
+        mLeftRack.mY1 = 1;
+    }
+    if(mLeftRack.mY1 + mRackLength > (mSize.height() - 60))
+    {
+        mLeftRack.mY1 -= 1;
+    }
+    mLeftRack.mY2 = mLeftRack.mY1 + mRackLength;
+
+    if (mRightRack.mY1 <= 0)
+    {
+        mRightRack.mY1 = 1;
+    }
+    if(mRightRack.mY1 + mRackLength > (mSize.height() - 60))
+    {
+        mRightRack.mY1 -= 1;
+    }
+    mRightRack.mY2 = mRightRack.mY1 + mRackLength;
+}
+
 void GameBoardWidget::paintEvent(QPaintEvent */*event*/)
 {
      QPainter painter(this);
      painter.save();
      painter.setPen(QPen(static_cast<QColor>(Qt::white), mRackPenSize, Qt::SolidLine, Qt::FlatCap, Qt::RoundJoin));
+
+     checkPositions();
 
      //painter.drawLine(5,7,25,30);
      painter.drawLine(mRightRack.mX1,mRightRack.mY1,mRightRack.mX2,mRightRack.mY2);

--- a/gameboardwidget.cpp
+++ b/gameboardwidget.cpp
@@ -1,6 +1,7 @@
 #include "gameboardwidget.h"
 #include <QPainter>
-
+#include <iostream>
+#include <unistd.h>
 
 GameBoardWidget::~GameBoardWidget()
 {
@@ -14,24 +15,41 @@ void GameBoardWidget::updateGameBoard()
 
 void GameBoardWidget::leftRackMove(int iDirection)
 {
-    if ((mLeftRack.mY1 + iDirection) >= 0 && (mLeftRack.mY1 + iDirection + mRackLength) <= (mSize.height() - 60))
+    while(mLMoving)
     {
-        mLeftRack.mY1 += iDirection;
-        mLeftRack.mY2 = mLeftRack.mY1 + mRackLength;
+        if ((mLeftRack.mY1 + iDirection) >= 0 && (mLeftRack.mY1 + iDirection + mRackLength) <= (mSize.height() - 60))
+        {
+            mLeftRack.mY1 += iDirection;
+            mLeftRack.mY2 = mLeftRack.mY1 + mRackLength;
+        }
+
+        sleep(1);
+        std::cout << "mLeftRack.mY1: " << mLeftRack.mY1 << std::endl;
+
+        update();
     }
 
-    update();
 }
 
 void GameBoardWidget::rightRackMove(int iDirection)
 {
-    if ((mRightRack.mY1 + iDirection) >= 0 && (mRightRack.mY1 + iDirection + mRackLength) <= (mSize.height() - 60))
+    while(mRMoving)
     {
-        mRightRack.mY1 += iDirection;
-        mRightRack.mY2 = mRightRack.mY1 + mRackLength;
+        if ((mRightRack.mY1 + iDirection) >= 0 && (mRightRack.mY1 + iDirection + mRackLength) <= (mSize.height() - 60))
+        {
+            mRightRack.mY1 += iDirection;
+            mRightRack.mY2 = mRightRack.mY1 + mRackLength;
+        }
+
+        std::cout << "mRightRack.mY1: " << mRightRack.mY1 << std::endl;
+
+        update();
+
+        sleep(1);
+
+
     }
 
-    update();
 }
 
 void GameBoardWidget::init(QSize iSize)

--- a/gameboardwidget.h
+++ b/gameboardwidget.h
@@ -17,6 +17,11 @@ public:
     ~GameBoardWidget();
     void init(QSize iSize);
 
+    Line mRightRack;
+    Line mLeftRack;
+
+    void checkPositions();
+
 public slots:
     void updateGameBoard();
     void leftRackMove(int iDirection);
@@ -26,8 +31,6 @@ protected:
     void paintEvent(QPaintEvent *event) override;
 
 private:
-    Line mRightRack;
-    Line mLeftRack;
     int mRackPenSize;
     int mRackLength;
     Point mBall;

--- a/gameboardwidget.h
+++ b/gameboardwidget.h
@@ -17,8 +17,10 @@ public:
 
     ~GameBoardWidget();
     void init(QSize iSize);
-    bool mRMoving = false;
-    bool mLMoving = false;
+    bool mRMovingUp = false;
+    bool mLMovingUp = false;
+    bool mRMovingDo = false;
+    bool mLMovingDo = false;
 
 
 public slots:
@@ -28,8 +30,6 @@ public slots:
 
 protected:
     void paintEvent(QPaintEvent *event) override;
-    //void keyPressEvent(QKeyEvent *event);
-    //void keyReleaseEvent(QKeyEvent *event);
 
 private:
     int mRackPenSize;
@@ -38,7 +38,7 @@ private:
     QSize mSize;
     Line mRightRack;
     Line mLeftRack;
-
+    int mRackSpeed;
     void checkPositions();
 };
 

--- a/gameboardwidget.h
+++ b/gameboardwidget.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 #include "line.h"
 #include "point.h"
+#include <QKeyEvent>
 
 class GameBoardWidget : public QWidget
 {
@@ -16,11 +17,9 @@ public:
 
     ~GameBoardWidget();
     void init(QSize iSize);
+    bool mRMoving = false;
+    bool mLMoving = false;
 
-    Line mRightRack;
-    Line mLeftRack;
-
-    void checkPositions();
 
 public slots:
     void updateGameBoard();
@@ -29,12 +28,18 @@ public slots:
 
 protected:
     void paintEvent(QPaintEvent *event) override;
+    //void keyPressEvent(QKeyEvent *event);
+    //void keyReleaseEvent(QKeyEvent *event);
 
 private:
     int mRackPenSize;
     int mRackLength;
     Point mBall;
     QSize mSize;
+    Line mRightRack;
+    Line mLeftRack;
+
+    void checkPositions();
 };
 
 #endif // GAMEBOARDWIDGET_H

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,5 +1,9 @@
 #include "mainwindow.h"
 #include <QtWidgets>
+#include <QTimer>
+#include <QKeyEvent>
+#include <iostream>
+
 
 MainWindow::MainWindow()
 {
@@ -8,9 +12,9 @@ MainWindow::MainWindow()
   m_button_new = new QPushButton("New game", this);
   connect(m_button_new, SIGNAL (clicked()), this, SLOT (buttonNewGame()));
 
-  timer = new QTimer(this);
-  connect(timer,SIGNAL(timeout()),this,SLOT(update()));
-  connect(timer,SIGNAL(timeout()),this,SLOT(buttonNewGame()));
+  //timer = new QTimer(this);
+  //connect(timer,SIGNAL(timeout()),this,SLOT(update()));
+  //connect(timer,SIGNAL(timeout()),this,SLOT(buttonNewGame()));
 
   QPalette pal = palette();
 
@@ -89,25 +93,65 @@ void MainWindow::rightRackDown()
 
 void MainWindow::keyPressEvent(QKeyEvent *event)
 {
+    std::cout << " Key is pressed: " ;
+        if( event->key() == Qt::Key_W )
+        {
+            std::cout << "W" << std::endl;
+            myGameBoard->mLMoving = true;
+            emit leftRackUp();
+
+            //myGameBoard->mLeftRack.mY1 -= 1;
+        }
+        if (event->key() == Qt::Key_S)
+        {
+            std::cout << "S" << std::endl;
+            myGameBoard->mLMoving = true;
+            emit leftRackDown();
+
+            //myGameBoard->mLeftRack.mY1 += 1;
+        }
+        if (event->key() == Qt::Key_O)
+        {
+            std::cout << "O" << std::endl;
+            myGameBoard->mRMoving = true;
+            emit rightRackUp();
+            //myGameBoard->mRightRack.mY1 -= 1;
+        }
+        if(event->key() == Qt::Key_L)
+        {
+            std::cout << "L" << std::endl;
+            myGameBoard->mRMoving = true;
+            emit rightRackDown();
+            //myGameBoard->mRightRack.mY1 -= 1;
+        }
+
+
+
+}
+
+void MainWindow::keyReleaseEvent(QKeyEvent *event)
+{
+    std::cout << "Key is released: " ;
     if( event->key() == Qt::Key_W )
     {
-        //emit leftRackUp();
-        myGameBoard->mLeftRack.mY1 -= 1;
+        std::cout << "W" << std::endl;
+        myGameBoard->mLMoving = false;
     }
     if (event->key() == Qt::Key_S)
     {
-        //emit leftRackDown();
-        myGameBoard->mLeftRack.mY1 += 1;
+        std::cout << "S" << std::endl;
+        myGameBoard->mLMoving = false;
     }
     if (event->key() == Qt::Key_O)
     {
-        //emit rightRackUp();
-        myGameBoard->mRightRack.mY1 -= 1;
+        std::cout << "O" << std::endl;
+        myGameBoard->mRMoving = false;
     }
     if(event->key() == Qt::Key_L)
     {
-        //emit rightRackDown();
-        myGameBoard->mRightRack.mY1 -= 1;
+        std::cout << "L" << std::endl;
+        myGameBoard->mRMoving = false;
     }
+    //myGameBoard->mLMoving = false;
 
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -8,6 +8,10 @@ MainWindow::MainWindow()
   m_button_new = new QPushButton("New game", this);
   connect(m_button_new, SIGNAL (clicked()), this, SLOT (buttonNewGame()));
 
+  timer = new QTimer(this);
+  connect(timer,SIGNAL(timeout()),this,SLOT(update()));
+  connect(timer,SIGNAL(timeout()),this,SLOT(buttonNewGame()));
+
   QPalette pal = palette();
 
   // set black background
@@ -87,19 +91,23 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
 {
     if( event->key() == Qt::Key_W )
     {
-        emit leftRackUp(); // connected elsewhere
+        //emit leftRackUp();
+        myGameBoard->mLeftRack.mY1 -= 1;
     }
     if (event->key() == Qt::Key_S)
     {
-        emit leftRackDown();
+        //emit leftRackDown();
+        myGameBoard->mLeftRack.mY1 += 1;
     }
     if (event->key() == Qt::Key_O)
     {
-        emit rightRackUp();
+        //emit rightRackUp();
+        myGameBoard->mRightRack.mY1 -= 1;
     }
     if(event->key() == Qt::Key_L)
     {
-        emit rightRackDown();
+        //emit rightRackDown();
+        myGameBoard->mRightRack.mY1 -= 1;
     }
 
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -12,9 +12,9 @@ MainWindow::MainWindow()
   m_button_new = new QPushButton("New game", this);
   connect(m_button_new, SIGNAL (clicked()), this, SLOT (buttonNewGame()));
 
-  //timer = new QTimer(this);
-  //connect(timer,SIGNAL(timeout()),this,SLOT(update()));
-  //connect(timer,SIGNAL(timeout()),this,SLOT(buttonNewGame()));
+  QTimer *timer = new QTimer(this);
+  connect(timer, SIGNAL(timeout()), this, SLOT(updateGameBoard()));
+  timer->start(100);
 
   QPalette pal = palette();
 
@@ -46,6 +46,12 @@ MainWindow::~MainWindow()
 void MainWindow::buttonNewGame()
 {
     myGameBoard->updateGameBoard();
+    // TODO: modify it to reset()..
+}
+
+void MainWindow::updateGameBoard()
+{
+    myGameBoard->updateGameBoard();
 }
 
 void MainWindow::centerAndResize() {
@@ -71,87 +77,63 @@ void MainWindow::centerAndResize() {
     );
 }
 
-void MainWindow::leftRackUp()
-{
-    myGameBoard->leftRackMove(UP);
-}
-
-void MainWindow::leftRackDown()
-{
-    myGameBoard->leftRackMove(DOWN);
-}
-
-void MainWindow::rightRackUp()
-{
-    myGameBoard->rightRackMove(UP);
-}
-
-void MainWindow::rightRackDown()
-{
-    myGameBoard->rightRackMove(DOWN);
-}
 
 void MainWindow::keyPressEvent(QKeyEvent *event)
 {
-    std::cout << " Key is pressed: " ;
+
+    if(!event->isAutoRepeat())
+    {
+        std::cout << " Key is pressed: " ;
         if( event->key() == Qt::Key_W )
         {
             std::cout << "W" << std::endl;
-            myGameBoard->mLMoving = true;
-            emit leftRackUp();
-
-            //myGameBoard->mLeftRack.mY1 -= 1;
+            myGameBoard->mLMovingUp = true;
         }
         if (event->key() == Qt::Key_S)
         {
             std::cout << "S" << std::endl;
-            myGameBoard->mLMoving = true;
-            emit leftRackDown();
-
-            //myGameBoard->mLeftRack.mY1 += 1;
+            myGameBoard->mLMovingDo = true;
         }
         if (event->key() == Qt::Key_O)
         {
             std::cout << "O" << std::endl;
-            myGameBoard->mRMoving = true;
-            emit rightRackUp();
-            //myGameBoard->mRightRack.mY1 -= 1;
+            myGameBoard->mRMovingUp = true;
         }
         if(event->key() == Qt::Key_L)
         {
             std::cout << "L" << std::endl;
-            myGameBoard->mRMoving = true;
-            emit rightRackDown();
-            //myGameBoard->mRightRack.mY1 -= 1;
+            myGameBoard->mRMovingDo = true;
         }
-
-
+    }
 
 }
 
 void MainWindow::keyReleaseEvent(QKeyEvent *event)
 {
-    std::cout << "Key is released: " ;
-    if( event->key() == Qt::Key_W )
+    if(!event->isAutoRepeat())
     {
-        std::cout << "W" << std::endl;
-        myGameBoard->mLMoving = false;
+        std::cout << "Key is released: " ;
+        if( event->key() == Qt::Key_W )
+        {
+            std::cout << "W" << std::endl;
+            myGameBoard->mLMovingUp = false;
+        }
+        if (event->key() == Qt::Key_S)
+        {
+            std::cout << "S" << std::endl;
+            myGameBoard->mLMovingDo = false;
+        }
+        if (event->key() == Qt::Key_O)
+        {
+            std::cout << "O" << std::endl;
+            myGameBoard->mRMovingUp = false;
+        }
+        if(event->key() == Qt::Key_L)
+        {
+            std::cout << "L" << std::endl;
+            myGameBoard->mRMovingDo = false;
+        }
     }
-    if (event->key() == Qt::Key_S)
-    {
-        std::cout << "S" << std::endl;
-        myGameBoard->mLMoving = false;
-    }
-    if (event->key() == Qt::Key_O)
-    {
-        std::cout << "O" << std::endl;
-        myGameBoard->mRMoving = false;
-    }
-    if(event->key() == Qt::Key_L)
-    {
-        std::cout << "L" << std::endl;
-        myGameBoard->mRMoving = false;
-    }
-    //myGameBoard->mLMoving = false;
+
 
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -29,10 +29,7 @@ protected:
 
 private slots:
     void buttonNewGame();
-    void leftRackUp();
-    void leftRackDown();
-    void rightRackUp();
-    void rightRackDown();
+    void updateGameBoard();
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -24,7 +24,8 @@ private:
    const int DOWN = 4;
 
 protected:
-   void keyPressEvent(QKeyEvent *event) override;
+   void keyPressEvent(QKeyEvent *event);
+   void keyReleaseEvent(QKeyEvent *event);
 
 private slots:
     void buttonNewGame();


### PR DESCRIPTION
A keypress event of qt breaks the previous keypress so the previously moved rack stops and the current start moving. 

By setting booleans in keypress events and handle movements by QTimer ticks stores the states and solves the problem.